### PR TITLE
Made constructor of MockCreator public.

### DIFF
--- a/src/Trakx.Utils.Testing/MockCreator.cs
+++ b/src/Trakx.Utils.Testing/MockCreator.cs
@@ -11,7 +11,7 @@ namespace Trakx.Utils.Testing
         protected static readonly string Alphabet = "abcdefghijklmnopqrstuvwxyz";
         protected readonly string Name;
 
-        protected MockCreator(ITestOutputHelper output)
+        public MockCreator(ITestOutputHelper output)
         {
             Name = output.GetCurrentTestName();
             Random = new Random(Name.GetHashCode());


### PR DESCRIPTION
So that I can use it in other projects without having to create a child mock creator class. #29

closes #29 